### PR TITLE
Blockquote styling

### DIFF
--- a/themes/datatogether/static/css/style.css
+++ b/themes/datatogether/static/css/style.css
@@ -296,7 +296,11 @@ dd {
   margin-left: 0; }
 
 blockquote {
-  margin: 0 0 1rem; }
+  margin-left: 1rem;
+  padding-left: 1rem;
+  border-left: 0.2rem solid lightgray;
+  font-family: "Helvetica Neue", Helvetica, sans-serif;
+  font-weight: 300;}
 
 a {
   color: #698736;


### PR DESCRIPTION
We didn't really have any styling around blockquotes (see https://github.com/datatogether/website/issues/43#issuecomment-499298239). This adds some.

Prior:
![59052506-156b0680-8844-11e9-9e75-5193d66aa012](https://user-images.githubusercontent.com/454690/59054445-8f04f380-8848-11e9-81b3-d9096295fa2e.png)

With this PR:
![Screen Shot 2019-06-06 at 10 46 17 AM](https://user-images.githubusercontent.com/454690/59054452-93311100-8848-11e9-8393-2625f2efd5ca.png)
