### PR TITLE
[WIP] Add "Join" page with Google calendar

### DIFF
--- a/content/join.md
+++ b/content/join.md
@@ -1,8 +1,35 @@
 ---
-title: "Join Us!"
+title: "Data. Together. Let's read about it!"
 date: 2019-10-20T18:00:00-04:00
 draft: false
 menu: main
 ---
+
+## Join Us!
+
+Data Together's reading group is a set of conversations on themes relevant to information and ethics.
+Curated reading selections are distributed once a month; we meet to discuss on video call.
+
+This year, we are creating **blog posts** of each of the conversations, which you can see at [datatogether.org](//datatogether.org).
+
+#### Spring - Summer 2020 Data Together Reading Group
+
+📅 17:30-19:00 ET Tuesdays [**Data Together Calendar**](https://calendar.google.com/calendar/embed?src=u75o4fbnv59006peo07nv67vsg%40group.calendar.google.com&ctz=America%2FToronto)  
+🎯 Participation link (recorded): [https://edgi-video-call-landing-page.herokuapp.com/https://zoom.us/j/847315566](https://edgi-video-call-landing-page.herokuapp.com/https://zoom.us/j/847315566)  
+▶️ [**Data Together Call Playlist**](https://www.youtube.com/playlist?list=PLtsP3g9LafVul1gCctMYGm9sz5FUWr5bu)
+
+Once a month, we'll host a 1.5 hour discussion of one of our [themes](https://github.com/datatogether/reading_datatogether#themes). Everyone should try hard to read the *core* reading (~30 pages), and once or twice sign up to [facilitate discussion](https://github.com/datatogether/reading_datatogether#facilitation). [**Join the Google Group**](https://groups.google.com/forum/embed/?place=forum/datatogether/join) to be notified of upcoming meetings and readings.
+
+Our hope is that:
+<ul>
+  <li>First, we learn together!</li>
+  <li>Second, through documenting discussion we can articulate Data Together principles.</li>
+</ul>
+
+---
+
+## Events
+
+<p>Find out when our next reading session is or other events related to the Decentralized Web.</p>
 
 <iframe src="https://calendar.google.com/calendar/embed?src=u75o4fbnv59006peo07nv67vsg%40group.calendar.google.com&ctz=America%2FNew_York" style="border: 0" width="800" height="600" frameborder="0" scrolling="no"></iframe>

--- a/content/join.md
+++ b/content/join.md
@@ -7,24 +7,7 @@ menu: main
 
 ## Join Us!
 
-Data Together's reading group is a set of conversations on themes relevant to information and ethics.
-Curated reading selections are distributed once a month; we meet to discuss on video call.
-
-This year, we are creating **blog posts** of each of the conversations, which you can see at [datatogether.org](//datatogether.org).
-
-#### Spring–Summer 2020 Data Together Reading Group
-
-📅 17:30-19:00 ET Tuesdays [**Data Together Calendar**](https://calendar.google.com/calendar/embed?src=u75o4fbnv59006peo07nv67vsg%40group.calendar.google.com&ctz=America%2FToronto)  
-🎯 Participation link (recorded): [https://edgi-video-call-landing-page.herokuapp.com/https://zoom.us/j/847315566](https://edgi-video-call-landing-page.herokuapp.com/https://zoom.us/j/847315566)  
-▶️ [**Data Together Call Playlist**](https://www.youtube.com/playlist?list=PLtsP3g9LafVul1gCctMYGm9sz5FUWr5bu)
-
-Once a month, we'll host a 1.5 hour discussion of one of our [themes](https://github.com/datatogether/reading_datatogether#themes). Everyone should try hard to read the *core* reading (~30 pages), and once or twice sign up to [facilitate discussion](https://github.com/datatogether/reading_datatogether#facilitation). [**Join the Google Group**](https://groups.google.com/forum/embed/?place=forum/datatogether/join) to be notified of upcoming meetings and readings.
-
-Our hope is that:
-<ul>
-  <li>First, we learn together!</li>
-  <li>Second, through documenting discussion we can articulate Data Together principles.</li>
-</ul>
+[**Join the Google Group**](https://groups.google.com/forum/embed/?place=forum/datatogether/join) to be notified of upcoming meetings and readings.
 
 ---
 

--- a/content/join.md
+++ b/content/join.md
@@ -12,7 +12,7 @@ Curated reading selections are distributed once a month; we meet to discuss on v
 
 This year, we are creating **blog posts** of each of the conversations, which you can see at [datatogether.org](//datatogether.org).
 
-#### Spring - Summer 2020 Data Together Reading Group
+#### Spring–Summer 2020 Data Together Reading Group
 
 📅 17:30-19:00 ET Tuesdays [**Data Together Calendar**](https://calendar.google.com/calendar/embed?src=u75o4fbnv59006peo07nv67vsg%40group.calendar.google.com&ctz=America%2FToronto)  
 🎯 Participation link (recorded): [https://edgi-video-call-landing-page.herokuapp.com/https://zoom.us/j/847315566](https://edgi-video-call-landing-page.herokuapp.com/https://zoom.us/j/847315566)  
@@ -30,6 +30,6 @@ Our hope is that:
 
 ## Events
 
-<p>Find out when our next reading session is or other events related to the Decentralized Web.</p>
+<p>Find out when our next reading session is happening and other events related to the Decentralized Web.</p>
 
-<iframe src="https://calendar.google.com/calendar/embed?src=u75o4fbnv59006peo07nv67vsg%40group.calendar.google.com&ctz=America%2FNew_York" style="border: 0" width="800" height="600" frameborder="0" scrolling="no"></iframe>
+<iframe src="https://calendar.google.com/calendar/b/1/embed?height=600&amp;wkst=1&amp;bgcolor=%23ffffff&amp;ctz=America%2FNew_York&amp;src=dTc1bzRmYm52NTkwMDZwZW8wN252Njd2c2dAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ&amp;color=%23C0CA33&amp;showTitle=0&amp;showNav=1&amp;showDate=1&amp;showPrint=0&amp;showTabs=1&amp;showCalendars=0" style="border-width:0" width="800" height="600" frameborder="0" scrolling="no"></iframe>

--- a/content/join.md
+++ b/content/join.md
@@ -1,0 +1,8 @@
+---
+title: "Join Us!"
+date: 2019-10-20T18:00:00-04:00
+draft: false
+menu: main
+---
+
+<iframe src="https://calendar.google.com/calendar/embed?src=u75o4fbnv59006peo07nv67vsg%40group.calendar.google.com&ctz=America%2FNew_York" style="border: 0" width="800" height="600" frameborder="0" scrolling="no"></iframe>

--- a/content/join.md
+++ b/content/join.md
@@ -5,14 +5,14 @@ draft: false
 menu: main
 ---
 
-## Join Us!
+## Join Us 
 
-[**Join the Google Group**](https://groups.google.com/forum/embed/?place=forum/datatogether/join) to be notified of upcoming meetings and readings.
+[**Join the Google Group**](https://groups.google.com/forum/embed/?place=forum/datatogether/join) to be notified of latest Data Together news. Everyone is welcome to join our sessions!
 
 ---
 
 ## Events
 
-<p>Find out when our next reading session is happening and other events related to the Decentralized Web.</p>
+<p>Find out when our next reading group session is happening and other events related to the Decentralized Web.</p>
 
 <iframe src="https://calendar.google.com/calendar/b/1/embed?height=600&amp;wkst=1&amp;bgcolor=%23ffffff&amp;ctz=America%2FNew_York&amp;src=dTc1bzRmYm52NTkwMDZwZW8wN252Njd2c2dAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ&amp;color=%23C0CA33&amp;showTitle=0&amp;showNav=1&amp;showDate=1&amp;showPrint=0&amp;showTabs=1&amp;showCalendars=0" style="border-width:0" width="800" height="600" frameborder="0" scrolling="no"></iframe>


### PR DESCRIPTION
This adds the `join` page to the site. There are some issues that need to be addressed before merging.

- #65 - new template so non-blogposts aren't put into blog
- #64 - new template without date in header