### PR TITLE
Upgrades CircleCI Hugo image to 0.60 and fixes raw html issue

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
         ignore:
           - gh-pages
     docker:
-      - image: felicianotech/docker-hugo:0.47.1
+      - image: cibuilds/hugo:0.60
     steps:
       - checkout
       - run:

--- a/content/about.md
+++ b/content/about.md
@@ -16,21 +16,24 @@ Data Together is an ongoing, inclusive conversation, an open source community, a
 
 Data Together was founded and is led by three partner organizations listed below, and comprises members across the world.
 
-<a href="/join"> <button type="button" class="btn btn-primary">Get involved</button> </a>
+{{< rawhtml >}}
+  <a href="/join"> <button type="button" class="btn btn-primary">Get involved</button> </a>
 
-<div class="container">
-  <div class="row">
-    <div class="col-md-4 col-sm-12 col-xs-12">
-      <a href="https://envirodatagov.org"><img src="/images/EDGI_Logo.png" width="100%" title="EDGI" alt="edgi"></a>
-    </div>
-    <div class="col-md-4 col-sm-12 col-xs-12">
-      <a href="https://qri.io"><img src="/images/blobs_with_large_text_black.png" width="100%" title="Qri" alt="Qri"></a>
-    </div>
-    <div class="col-md-4 col-sm-12 col-xs-12">
-      <a href="https://protocol.ai/"><img src="/images/PL_Logo.png" width="100%" title="Protocol Labs" alt="Protocol Labs"></a>
-    </div>
-  <div>
-</div>
+  <div class="container">
+    <div class="row">
+      <div class="col-md-4 col-sm-12 col-xs-12">
+        <a href="https://envirodatagov.org"><img src="/images/EDGI_Logo.png" width="100%" title="EDGI" alt="edgi"></a>
+      </div>
+      <div class="col-md-4 col-sm-12 col-xs-12">
+        <a href="https://qri.io"><img src="/images/blobs_with_large_text_black.png" width="100%" title="Qri" alt="Qri"></a>
+      </div>
+      <div class="col-md-4 col-sm-12 col-xs-12">
+        <a href="https://protocol.ai/"><img src="/images/PL_Logo.png" width="100%" title="Protocol Labs" alt="Protocol Labs"></a>
+      </div>
+    <div>
+  </div>
+{{< /rawhtml >}}
+
 
 
 

--- a/content/join.md
+++ b/content/join.md
@@ -9,7 +9,8 @@ draft: false
 ---
 
 ## Events
+{{< rawhtml >}}
+  <p>Find out when our next reading group session is happening and other events related to the Decentralized Web.</p>
 
-<p>Find out when our next reading group session is happening and other events related to the Decentralized Web.</p>
-
-<iframe src="https://calendar.google.com/calendar/b/1/embed?height=600&amp;wkst=1&amp;bgcolor=%23ffffff&amp;ctz=America%2FNew_York&amp;src=dTc1bzRmYm52NTkwMDZwZW8wN252Njd2c2dAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ&amp;color=%23C0CA33&amp;showTitle=0&amp;showNav=1&amp;showDate=1&amp;showPrint=0&amp;showTabs=1&amp;showCalendars=0" style="border-width:0" width="800" height="600" frameborder="0" scrolling="no"></iframe>
+  <iframe src="https://calendar.google.com/calendar/b/1/embed?height=600&amp;wkst=1&amp;bgcolor=%23ffffff&amp;ctz=America%2FNew_York&amp;src=dTc1bzRmYm52NTkwMDZwZW8wN252Njd2c2dAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ&amp;color=%23C0CA33&amp;showTitle=0&amp;showNav=1&amp;showDate=1&amp;showPrint=0&amp;showTabs=1&amp;showCalendars=0" style="border-width:0" width="800" height="600" frameborder="0" scrolling="no"></iframe>
+{{< /rawhtml >}}

--- a/content/media.md
+++ b/content/media.md
@@ -3,28 +3,29 @@ title: "Media"
 date: 2019-11-25T19:05:59-08:00
 draft: false
 ---
-<section>
-  <div class="container">
-    <div class="row">
-      <div class="text col-md-4">
-        <p><a href="http://2017.code4lib.org/">Code4Lib 2017</a></p>
-        <iframe max-height="315" width="100%" src="https://www.youtube.com/embed/xRuPShYelm4" frameborder="0" allowfullscreen></iframe>
-        <p>Golden Age for Libraries - Storing Data Together</p>
-        <p>Slides: <a href="presentations/Code4Lib%202017%20-%20Golden%20Age%20for%20Libraries%20-%20Storing%20Data%20Together.pdf">PDF</a>, <a href="presentations/Code4Lib%202017%20-%20Golden%20Age%20for%20Libraries%20-%20Storing%20Data%20Together.key">Keynote</a> </p>
-      </div>
-      <div class="text col-md-4">
-        <p><a href="http://www.esipfed.org/meetings/upcoming-meetings/esip-summer-meeting-2017">ESIP 2017 Summer Meeting</a></p>
-        <iframe max-height="315" width="100%" src="https://www.youtube.com/embed/8fP4M0iAYGs?t=1h7m42s" frameborder="0" allowfullscreen></iframe>
-        <p>Data Together</p>
-        <p>Slides: <a href="presentations/Data%20Together%20-%20ESIP%20Summer%20Meeting%20July%202017.pdf">PDF</a>, <a href="presentations/Data%20Together%20-%20ESIP%20Summer%20Meeting%20July%202017.key">Keynote</a> </p>
-      </div>
-      <div class="text col-md-4">
-        <p><a href="https://archive.org/details/ndsr-dc-2017">NDSR Symposium at the World Bank</a></p>
-        <iframe src="https://archive.org/embed/ndsr-dc-2017/04_Speaker_3_Matt_Zumwalt.mp4" max-height="315" width="100%" frameborder="0" webkitallowfullscreen="true" mozallowfullscreen="true" allowfullscreen></iframe>
-        <p>Swadeshi (starts at 1:10)</p>
-        <p>Slides: <a href="/presentations/Data%20Together%20-%20NDSR%20-%20swadeshi.pdf">PDF</a>, <a href="/presentations/Data%20Together%20-%20NDSR%20-%20swadeshi.key">Keynote</a> </p>
+{{< rawhtml >}}
+  <section>
+    <div class="container">
+      <div class="row">
+        <div class="text col-md-4">
+          <p><a href="http://2017.code4lib.org/">Code4Lib 2017</a></p>
+          <iframe max-height="315" width="100%" src="https://www.youtube.com/embed/xRuPShYelm4" frameborder="0" allowfullscreen></iframe>
+          <p>Golden Age for Libraries - Storing Data Together</p>
+          <p>Slides: <a href="presentations/Code4Lib%202017%20-%20Golden%20Age%20for%20Libraries%20-%20Storing%20Data%20Together.pdf">PDF</a>, <a href="presentations/Code4Lib%202017%20-%20Golden%20Age%20for%20Libraries%20-%20Storing%20Data%20Together.key">Keynote</a> </p>
+        </div>
+        <div class="text col-md-4">
+          <p><a href="http://www.esipfed.org/meetings/upcoming-meetings/esip-summer-meeting-2017">ESIP 2017 Summer Meeting</a></p>
+          <iframe max-height="315" width="100%" src="https://www.youtube.com/embed/8fP4M0iAYGs?t=1h7m42s" frameborder="0" allowfullscreen></iframe>
+          <p>Data Together</p>
+          <p>Slides: <a href="presentations/Data%20Together%20-%20ESIP%20Summer%20Meeting%20July%202017.pdf">PDF</a>, <a href="presentations/Data%20Together%20-%20ESIP%20Summer%20Meeting%20July%202017.key">Keynote</a> </p>
+        </div>
+        <div class="text col-md-4">
+          <p><a href="https://archive.org/details/ndsr-dc-2017">NDSR Symposium at the World Bank</a></p>
+          <iframe src="https://archive.org/embed/ndsr-dc-2017/04_Speaker_3_Matt_Zumwalt.mp4" max-height="315" width="100%" frameborder="0" webkitallowfullscreen="true" mozallowfullscreen="true" allowfullscreen></iframe>
+          <p>Swadeshi (starts at 1:10)</p>
+          <p>Slides: <a href="/presentations/Data%20Together%20-%20NDSR%20-%20swadeshi.pdf">PDF</a>, <a href="/presentations/Data%20Together%20-%20NDSR%20-%20swadeshi.key">Keynote</a> </p>
+        </div>
       </div>
     </div>
-  </div>
-</section>
-
+  </section>
+{{ < /rawhtml >}}

--- a/layouts/shortcodes/rawhtml.html
+++ b/layouts/shortcodes/rawhtml.html
@@ -1,0 +1,2 @@
+<!-- raw html -->
+{{.Inner}}


### PR DESCRIPTION
Fixes #87 

I pointed our new image at https://github.com/cibuilds/hugo. It looks to be run by the same maintainer `FelicianoTech` that our current image is pointing at.

Not sure if we should do this in separate PRs (updating the image and shortcode for raw html), but because upgrading would break the new site, thought this should happen together.

Also, not sure how to test this without just merging. Please, let me know what y'all think about how to proceed!